### PR TITLE
Use /usr/bin/env to specify python3 interpreter for better compatibility

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mlat-client (0.2.11) UNRELEASED; urgency=medium
+
+  * in development
+
+ -- Oliver Jowett <oliver@mutability.co.uk>  Mon, 18 Nov 2019 13:53:02 +0800
+
 mlat-client (0.2.10) stable; urgency=medium
 
   * Fix handling of special (synthetic mlat / zero) message timestamps

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
-mlat-client (0.2.11) UNRELEASED; urgency=medium
+mlat-client (0.2.11) stable; urgency=medium
 
-  * in development
+  * Do a sanity check on reported radarcape positions
+  * Adjust UDP datagram size to follow reported route MTU
+  * Make setup.py use env to find python3 interpreter (PR #17)
 
- -- Oliver Jowett <oliver@mutability.co.uk>  Mon, 18 Nov 2019 13:53:02 +0800
+ -- Oliver Jowett <oliver.jowett@flightaware.com>  Mon, 30 Dec 2019 22:14:59 +0800
 
 mlat-client (0.2.10) stable; urgency=medium
 

--- a/fa-mlat-client
+++ b/fa-mlat-client
@@ -47,6 +47,7 @@ def main():
     adept.start(coordinator)
     coordinator.run_until(lambda: adept.closed)
 
+
 if __name__ == '__main__':
     try:
         main()

--- a/mlat-client
+++ b/mlat-client
@@ -98,5 +98,6 @@ location pin from the coverage maps.""",
     server.start()
     coordinator.run_forever()
 
+
 if __name__ == '__main__':
     main()

--- a/mlat/client/coordinator.py
+++ b/mlat/client/coordinator.py
@@ -333,10 +333,12 @@ class Coordinator:
                 "is not supported; use a separate mlat-client for each receiver.")
 
     def received_radarcape_position_event(self, message, now):
-        self.server.send_position_update(message.eventdata['lat'],
-                                         message.eventdata['lon'],
-                                         message.eventdata['alt'],
-                                         'egm96_meters')
+        lat, lon = message.eventdata['lat'], message.eventdata['lon']
+        if lat >= -90 and lat <= 90 and lon >= -180 and lon <= -180:
+            self.server.send_position_update(lat, lon,
+                                             message.eventdata['lon'],
+                                             message.eventdata['alt'],
+                                             'egm96_meters')
 
     def received_df_misc(self, message, now):
         ac = self.aircraft.get(message.address)

--- a/mlat/client/output.py
+++ b/mlat/client/output.py
@@ -50,7 +50,7 @@ class OutputListener(LoggingMixin, asyncore.dispatcher):
             self.set_reuse_addr()
             self.bind(('', port))
             self.listen(5)
-        except:
+        except Exception:
             self.close()
             raise
 

--- a/mlat/client/util.py
+++ b/mlat/client/util.py
@@ -62,6 +62,7 @@ def monotonic_time():
     _last = now
     return now + _adjust
 
+
 try:
     # try to use the 3.3+ version when available
     from time import monotonic as monotonic_time  # noqa

--- a/mlat/client/version.py
+++ b/mlat/client/version.py
@@ -18,4 +18,4 @@
 
 """Just a version constant!"""
 
-CLIENT_VERSION = "0.2.10"
+CLIENT_VERSION = "0.2.11"

--- a/run-flake8.sh
+++ b/run-flake8.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 D=`dirname $0`
-python3 /usr/lib/python3/dist-packages/flake8/run.py --exclude=.git,__pycache__,build,debian mlat-client fa-mlat-client $D
+flake8 --exclude=.git,__pycache__,build,debian,tools mlat-client fa-mlat-client $D

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Part of mlat-client - an ADS-B multilateration client.
 # Copyright 2015, Oliver Jowett <oliver@mutability.co.uk>


### PR DESCRIPTION
This enables the setup script to work on systems without a hardcoded `/usr/bin/python3`