### PR TITLE
Detect if we receive MLAT packets, and ignore them

### DIFF
--- a/mlat/client/receiver.py
+++ b/mlat/client/receiver.py
@@ -207,7 +207,8 @@ class ReceiverConnection(ReconnectingConnection):
 
         global_stats.receiver_rx_messages += self.reader.received_messages
         global_stats.receiver_rx_filtered += self.reader.suppressed_messages
-        self.reader.received_messages = self.reader.suppressed_messages = 0
+        global_stats.receiver_rx_mlat     += self.reader.mlat_messages
+        self.reader.received_messages = self.reader.suppressed_messages = self.reader.mlat_messages = 0
 
         if messages:
             self.coordinator.input_received_messages(messages)

--- a/mlat/client/stats.py
+++ b/mlat/client/stats.py
@@ -37,6 +37,7 @@ class Stats:
         self.receiver_rx_bytes = 0
         self.receiver_rx_messages = 0
         self.receiver_rx_filtered = 0
+        self.receiver_rx_mlat = 0
         self.mlat_positions = 0
 
     def log_and_reset(self):
@@ -48,6 +49,9 @@ class Stats:
             self.receiver_rx_messages / elapsed,
             processed / elapsed,
             0 if self.receiver_rx_messages == 0 else 100.0 * processed / self.receiver_rx_messages)
+        if self.receiver_rx_mlat:
+            log('WARNING: Ignored {0:5d} messages with MLAT magic timestamp (do you have --forward-mlat on?)',
+                self.receiver_rx_mlat)
         log('Server:   {0:6.1f} kB/s from server   {1:4.1f}kB/s TCP to server  {2:6.1f}kB/s UDP to server',
             self.server_rx_bytes / elapsed / 1000.0,
             self.server_tx_bytes / elapsed / 1000.0,

--- a/mlat/client/version.py
+++ b/mlat/client/version.py
@@ -18,4 +18,4 @@
 
 """Just a version constant!"""
 
-CLIENT_VERSION = "0.2.10r1"
+CLIENT_VERSION = "0.2.10"

--- a/mlat/client/version.py
+++ b/mlat/client/version.py
@@ -18,4 +18,4 @@
 
 """Just a version constant!"""
 
-CLIENT_VERSION = "0.2.10"
+CLIENT_VERSION = "0.2.10r1"

--- a/modes_reader.c
+++ b/modes_reader.c
@@ -63,6 +63,7 @@ typedef struct {
     /* stats */
     unsigned int received_messages;
     unsigned int suppressed_messages;
+    unsigned int mlat_messages;
 } modesreader;
 
 /* methods for the modesreader type */
@@ -91,6 +92,7 @@ static PyMemberDef modesreaderMembers[] = {
     { "modeac_filter",         T_OBJECT,    offsetof(modesreader, modeac_filter),         0,         "Mode A/C accept filter"},
     { "received_messages",     T_UINT,      offsetof(modesreader, received_messages),     0,         "total number of messages decoded"},
     { "suppressed_messages",   T_UINT,      offsetof(modesreader, suppressed_messages),   0,         "number of messages suppressed by filtering"},
+    { "mlat_messages",         T_UINT,      offsetof(modesreader, mlat_messages),         0,         "number of incoming MLAT messages received (and ignored)"},
     { NULL, 0, 0, 0, NULL }
 };
 
@@ -240,7 +242,7 @@ static PyObject *modesreader_new(PyTypeObject *type, PyObject *args, PyObject *k
     Py_INCREF(Py_None); self->specific_filter = Py_None;
     Py_INCREF(Py_None); self->modeac_filter = Py_None;
 
-    self->received_messages = self->suppressed_messages = 0;
+    self->received_messages = self->suppressed_messages = self->mlat_messages = 0;
 
     return (PyObject *)self;
 }
@@ -861,15 +863,22 @@ static PyObject *feed_beast(modesreader *self, Py_buffer *buffer, int max_messag
 
         /* apply filters, update seen-set */
         ++self->received_messages;
-        wanted = filter_message(self, message);
-        if (wanted < 0)
-            goto out;
-        else if (wanted)
-            messages[message_count++] = message;
-        else {
+
+        if (is_synthetic_timestamp(timestamp)) {
             ++self->suppressed_messages;
-            Py_DECREF(message);
-        }
+            ++self->mlat_messages;
+	    Py_DECREF(message);
+	} else {
+            wanted = filter_message(self, message);
+            if (wanted < 0)
+                goto out;
+            else if (wanted)
+                messages[message_count++] = message;
+            else {
+                ++self->suppressed_messages;
+                Py_DECREF(message);
+            }
+	}
 
         p = m;
     }
@@ -1421,6 +1430,7 @@ static int filter_message(modesreader *self, PyObject *o)
     }
 
     if (message->timestamp == MAGIC_MLAT_TIMESTAMP && !self->want_mlat_messages) {
+        ++self->mlat_messages;
         return 0;
     }
 


### PR DESCRIPTION
If a message has the magic MLAT timestamp, ignore it.  Then complain whenever we dump out stats.

This situation can happen if someone is using '--forward-mlat' on dump1090 or readsb.  This patch allows people to still run that, without causing issues w/ MLAT.

(You should not be using MLAT-generated data to then again calculate MLAT info)