### PR TITLE
More-agressively drop MLAT packets we're fed

### DIFF
--- a/mlat/client/receiver.py
+++ b/mlat/client/receiver.py
@@ -207,7 +207,8 @@ class ReceiverConnection(ReconnectingConnection):
 
         global_stats.receiver_rx_messages += self.reader.received_messages
         global_stats.receiver_rx_filtered += self.reader.suppressed_messages
-        self.reader.received_messages = self.reader.suppressed_messages = 0
+        global_stats.receiver_rx_mlat     += self.reader.mlat_messages
+        self.reader.received_messages = self.reader.suppressed_messages = self.reader.mlat_messages = 0
 
         if messages:
             self.coordinator.input_received_messages(messages)

--- a/mlat/client/stats.py
+++ b/mlat/client/stats.py
@@ -37,6 +37,7 @@ class Stats:
         self.receiver_rx_bytes = 0
         self.receiver_rx_messages = 0
         self.receiver_rx_filtered = 0
+        self.receiver_rx_mlat = 0
         self.mlat_positions = 0
 
     def log_and_reset(self):
@@ -48,6 +49,9 @@ class Stats:
             self.receiver_rx_messages / elapsed,
             processed / elapsed,
             0 if self.receiver_rx_messages == 0 else 100.0 * processed / self.receiver_rx_messages)
+        if self.receiver_rx_mlat:
+            log('WARNING: Ignored {0:5d} messages with MLAT magic timestamp (do you have --forward-mlat on?)',
+                self.receiver_rx_mlat)
         log('Server:   {0:6.1f} kB/s from server   {1:4.1f}kB/s TCP to server  {2:6.1f}kB/s UDP to server',
             self.server_rx_bytes / elapsed / 1000.0,
             self.server_tx_bytes / elapsed / 1000.0,


### PR DESCRIPTION
* Move check for MLAT timestamp up/earlier in filter_message routine
* Keep track of these and complain when dumping stats, since this is usually caused by having --forward-mlat enabled on dump1090/readsb.