### PR TITLE
Fix to support south america

### DIFF
--- a/mlat-client
+++ b/mlat-client
@@ -87,11 +87,6 @@ location pin from the coverage maps.""",
 
     util.suppress_log_timestamps = not args.log_timestamps
 
-    if args.lat < 0.1 and args.lon < 0.1:
-        util.log("<3>Latitude / Longitude not set, please configure and reboot")
-        time.sleep(3600)
-        raise SystemExit
-
     util.log("mlat-client {version} starting up", version=mlat.client.version.CLIENT_VERSION)
 
     outputs = options.build_outputs(args)


### PR DESCRIPTION
Current lines exclude operation in negative latitudes and longitude. Removed that code which blocks operation in south america and all southern western quadrant.